### PR TITLE
Updated so that the program no longer adds a header to the bed file -…

### DIFF
--- a/bed2hgvs.py
+++ b/bed2hgvs.py
@@ -264,15 +264,20 @@ def process_bed_file(bed_file_location, config_dict, output_location, transcript
 
 		for row in reader:
 
-			hgvs_description = process_bed_line(row[0], row[1], row[2],wsdl_o, transcript_map, config_dict )
+			if row[0][0] == '#':
 
-			bed_list.append([row[0], row[1], row[2], hgvs_description])
+				bed_list.append([row[0]])
+
+			else:
+
+				hgvs_description = process_bed_line(row[0], row[1], row[2],wsdl_o, transcript_map, config_dict )
+
+				bed_list.append([row[0], row[1], row[2], hgvs_description])
 
 
 	with open(output_location, 'w') as csvfile:
 
 		# Add header to bed file.
-		csvfile.write('#track name=coverage_gaps description="{info} coverage gaps annotated"\n'.format(info=info_string))
 
 		writer = csv.writer(csvfile, delimiter='\t')
 

--- a/test_data/error_different_transcripts_output.bed
+++ b/test_data/error_different_transcripts_output.bed
@@ -1,2 +1,1 @@
-#track name=coverage_gaps description="Using Mutalyser: 2.0.28 with nomenclature version 2.0 coverage gaps annotated"
 17	7572921	9572928	ERROR1

--- a/test_data/error_unknown_transcripts_output.bed
+++ b/test_data/error_unknown_transcripts_output.bed
@@ -1,3 +1,2 @@
-#track name=coverage_gaps description="Using Mutalyser: 2.0.28 with nomenclature version 2.0 coverage gaps annotated"
 1	115252202	115252220	ERROR2
 17	7577013	7577017	TP53(NM_000546.4):c.919+2_919+5

--- a/test_data/forward_test_output.bed
+++ b/test_data/forward_test_output.bed
@@ -1,3 +1,2 @@
-#track name=coverage_gaps description="Using Mutalyser: 2.0.28 with nomenclature version 2.0 coverage gaps annotated"
 7	55086795	55086810	EGFR(NM_005228.3):c.-175_-161
 7	55087000	55087050	EGFR(NM_005228.3):c.31_80

--- a/test_data/pass_output.bed
+++ b/test_data/pass_output.bed
@@ -1,4 +1,3 @@
-#track name=coverage_gaps description="Using Mutalyser: 2.0.28 with nomenclature version 2.0 coverage gaps annotated"
 17	7572921	7572928	TP53(NM_000546.4):c.1181_*5
 17	7573921	7573994	TP53(NM_000546.4):c.1033_1100+5
 17	7577013	7577017	TP53(NM_000546.4):c.919+2_919+5

--- a/tests.py
+++ b/tests.py
@@ -25,8 +25,6 @@ class ProcessBedFileTest(unittest.TestCase):
 
 			spamreader = csv.reader(csvfile, delimiter='\t')
 
-			next(spamreader, None)
-
 			i = 0
 
 			for row in spamreader:
@@ -51,8 +49,6 @@ class ProcessBedFileTest(unittest.TestCase):
 		with open('test_data/error_different_transcripts_output.bed', 'r') as csvfile:
 
 			spamreader = csv.reader(csvfile, delimiter='\t')
-
-			next(spamreader, None)
 
 			i = 0
 
@@ -80,8 +76,6 @@ class ProcessBedFileTest(unittest.TestCase):
 
 			spamreader = csv.reader(csvfile, delimiter='\t')
 
-			next(spamreader, None)
-
 			i = 0
 
 			for row in spamreader:
@@ -106,8 +100,6 @@ class ProcessBedFileTest(unittest.TestCase):
 		with open('test_data/forward_test_output.bed', 'r') as csvfile:
 
 			spamreader = csv.reader(csvfile, delimiter='\t')
-
-			next(spamreader, None)
 
 			i = 0
 


### PR DESCRIPTION
* removed line from bed2hgvs.py which adds header
* if the input header line starts with # the program will skip processing, but include in output bed.
* updated tests to reflect new output